### PR TITLE
Fix snapshot request bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def save_orderbook(symbol: str = 'fUSD'):
         # Request orderbook information.
         print("")
         print('GETTING ORDER BOOK INFORMATION')
-        url = 'https://api-pub.bitfinex.com/v2/book/fUSD/P0?_full=1'
+        url = f'https://api-pub.bitfinex.com/v2/book/{symbol}/P0?_full=1'
         request = requests.get(url)
         full_book = request.json()  # Gets a list from full book.
 


### PR DESCRIPTION
Program was ignoring pair information when requesting orderbook snapshot. Always storing 'fUSD'